### PR TITLE
Undefined WIN32 macro

### DIFF
--- a/src/common/runtime/logging.cpp
+++ b/src/common/runtime/logging.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <utility/asyncQueue.h>
 
-#if WIN32
+#if _WIN32
 #include <windows.h>
 #endif
 
@@ -21,7 +21,7 @@ namespace Logging
     std::vector<std::function<void(const Log&)>> _logListeners;
     AsyncQueue<Log> _logEvents;
 
-#if WIN32
+#if _WIN32
     HANDLE hConsole;
 #endif
 
@@ -29,7 +29,7 @@ namespace Logging
     tm& getLocalTime()
     {
         const time_t now = time(0);
-#if WIN32
+#if _WIN32
         localtime_s(&ltm_global, &now);
 #else
         localtime_r(&now, &ltm_global);
@@ -51,7 +51,7 @@ namespace Logging
         if(!_logFile.is_open())
             throw std::runtime_error("Could not generate log file");
 
-#if WIN32
+#if _WIN32
         hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
 #endif
     }

--- a/src/common/ui/gui.cpp
+++ b/src/common/ui/gui.cpp
@@ -127,7 +127,7 @@ void GUI::setupImGui(graphics::VulkanRuntime& runtime)
     io.ConfigFlags   |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
     //io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;    // Enable Gamepad Controls
     io.ConfigFlags   |= ImGuiConfigFlags_DockingEnable;         // Enable docking
-#ifdef WIN32
+#ifdef _WIN32
     //io.ConfigFlags   |= ImGuiConfigFlags_ViewportsEnable;
 #endif
     io.IniFilename = NULL;

--- a/src/common/utility/stackAllocate.h
+++ b/src/common/utility/stackAllocate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef WIN32
+#ifdef _WIN32
 #define STACK_ALLOCATE(x) _alloca(x)
 #else
 #include <alloca.h>

--- a/src/editor/widgets/assetBrowserWidget.cpp
+++ b/src/editor/widgets/assetBrowserWidget.cpp
@@ -263,7 +263,7 @@ void AssetBrowserWidget::displayFiles()
             if(ImGui::Selectable(ICON_FA_FOLDER " Show In File Browser"))
             {
 
-#ifdef WIN32
+#ifdef _WIN32
                 const std::string fileBrowser = "explorer \"";
 #elif __unix__
                 const std::string fileBrowser = "dolphin \"";
@@ -277,7 +277,7 @@ void AssetBrowserWidget::displayFiles()
                 {
                     if(getFileType(_contents[_selectedFiles.x]) == FileType::source && ImGui::Selectable(ICON_FA_UP_RIGHT_FROM_SQUARE " Edit"))
                     {
-#ifdef WIN32
+#ifdef _WIN32
                         const std::string osCommand = R"(start "" ")";
 #elif __unix__
                         const std::string osCommand = "xdg-open \"";


### PR DESCRIPTION
There's no `WIN32` marco, only default `_WIN32` macro [defined by MSVC on Windows](https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-170). Unless there's some macro that isn't being set, this will not compile neither on MinGW or MSVC. Maybe leaky macro? 