### PR TITLE
Misplaced namespace in member name

### DIFF
--- a/src/assetServer/assetServer.h
+++ b/src/assetServer/assetServer.h
@@ -44,7 +44,7 @@ class AssetServer : public Module
     std::mutex _sendersLock;
     std::list<IncrementalAssetSender> _senders;
 
-    std::filesystem::path AssetServer::assetPath(const AssetID& id);
+    std::filesystem::path assetPath(const AssetID& id);
 
     AsyncData<Asset*> fetchAssetCallback(const AssetID& id, bool incremental);
 


### PR DESCRIPTION
Probably just refactoring typo. 